### PR TITLE
Update profile README with current open source work

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,30 +6,67 @@ Currently at Singapore's largest grocery retailer, where I build LLM platforms, 
 
 ## What I'm Working On
 
-- Building production GenAI systems (LLM platforms, content generation, compliance)
-- Developing AI tooling in Rust (MCP servers, CLI tools)
-- Exploring on-device AI and edge ML
+- Systems programming in C and Rust for Apple Silicon (inference kernels, thermal control, SMC/IOKit)
+- Local and on-device LLM inference: Metal kernels, GGUF, MLX, benchmarking real hardware limits
+- AI developer tooling: MCP servers, CLIs, and a local-first memory graph
 
-## Featured Projects
+## Projects
+
+### Systems & CLI
 
 | Project | Description | Tech |
 |---------|-------------|------|
-| [atlassian-cli](https://github.com/omar16100/atlassian-cli) | CLI for Atlassian Cloud (Jira, Confluence, Bitbucket) | Rust |
-| [parsnip](https://github.com/omar16100/parsnip) | Memory graph for AI assistants | Rust, MCP |
-| [gemini-mcp-rust](https://github.com/omar16100/gemini-mcp-rust) | High-performance MCP server for Gemini | Rust |
+| [atlassian-cli](https://github.com/omar16100/atlassian-cli) | Unified CLI for Jira, Confluence, Bitbucket & JSM. Bulk ops, dry-run, JSON/CSV/YAML output, multi-instance profiles. [Docs](https://atlassiancli.com/) | Rust |
+| [surge](https://github.com/omar16100/surge) | LLM inference engine for the Mac Studio M3 Ultra. Limiter-aware pacing scheduler, byte-exact Metal decode, no dependencies beyond macOS. Work in progress | C, Metal |
+| [fanpro](https://github.com/omar16100/fanpro) | Fan control and thermal monitoring for Apple Silicon. CLI, TUI and root daemon, zero dependencies | C, IOKit |
+| [speedlog](https://github.com/omar16100/speedlog) | Internet speed monitor. One bash script, one HTML file, no Docker, no database | Bash, HTML |
+| [batteryconsole](https://github.com/omar16100/batteryconsole) | Logitech MX device battery levels on macOS | Rust |
+| [logi_mx_auto_switch](https://github.com/omar16100/logi_mx_auto_switch) | Make an MX Master follow the MX Keys across Macs via HID++ ChangeHost, no Logitech software | Python |
+
+### AI Tooling
+
+| Project | Description | Tech |
+|---------|-------------|------|
+| [parsnip](https://github.com/omar16100/parsnip) | Local-first memory graph for AI assistants. Single binary, entities/relations/observations, 5 search modes, cross-project queries. [Site](https://omar16100.github.io/parsnip/) | Rust, redb, tantivy, MCP |
+| [gemini-mcp-rust](https://github.com/omar16100/gemini-mcp-rust) | MCP server for Google's Gemini API | Rust, MCP |
+| [reddit-mcp-server](https://github.com/omar16100/reddit-mcp-server) | Read-only Reddit MCP server over app-only OAuth | Rust, MCP |
+| [skills](https://github.com/omar16100/skills) | Custom skills for the Claude Code CLI | Markdown |
+
+### ML & Experiments
+
+| Project | Description | Tech |
+|---------|-------------|------|
+| [llm-benchmark](https://github.com/omar16100/llm-benchmark) | Local LLM benchmark suite: 26 prompts, 6 categories, programmatic plus LLM-as-judge scoring | Python |
+| [bengali-ocr-finetune](https://github.com/omar16100/bengali-ocr-finetune) | Bengali OCR fine-tuning on Apple Silicon with mlx-vlm | Python, MLX |
+
+### Web
+
+| Project | Description | Tech |
+|---------|-------------|------|
+| [saas_template](https://github.com/omar16100/saas_template) | Cloudflare-first SaaS starter. Opinionated, SEO-first, swappable. [Demo](https://omar16100.github.io/saas_template/) | Next.js 16, D1, Better Auth, Stripe |
+
+*atlassian-cli: 28 stars, 7,217 GitHub release downloads, 541 crates.io downloads (as of 27 Aug 2026).*
+
+## Contributing Elsewhere
+
+Open source contributions to [psd-tools](https://github.com/psd-tools/psd-tools) (drop shadow and outer glow layer effect rendering), [App-Store-Connect-CLI](https://github.com/rorkai/App-Store-Connect-CLI) (submission validation, localization updates, price filtering), [whatsapp-mcp](https://github.com/lharries/whatsapp-mcp), [HistoryHound](https://github.com/pkmishra/HistoryHound), and [aws-samples](https://github.com/aws-samples).
 
 ## Tech Stack
 
-**ML/AI**: Python, TensorFlow, PyTorch, LangChain, Computer Vision, NLP
-**Backend**: Go, Rust, Flask, FastAPI
-**Cloud**: GCP (Vertex AI, BigQuery, Cloud Functions), AWS (SageMaker, Lambda)
-**Infrastructure**: Kubernetes, Docker, Terraform, Airflow
+**Systems**: Rust, C, Metal, IOKit
+**ML/AI**: Python, PyTorch, MLX, GGUF, llama.cpp, Computer Vision, NLP
+**AI tooling**: Model Context Protocol (MCP), Claude Code
+**Web**: TypeScript, Next.js, Cloudflare Workers/D1
+**Cloud**: GCP (Vertex AI, BigQuery, Cloud Functions), AWS (SageMaker, Lambda), Kubernetes, Docker
 
 ## Talks & Writing
 
-- [Serving ML Models Serverlessly](https://www.youtube.com/watch?v=Fon3xvdAKe4) - AWS UG Malaysia
+- [macOS clamps my M3 Ultra's GPU to 338 MHz before the fans even try](https://omarshabab.com/mac-studio-firmware-gpu-limiter/)
+- [Kimi-Linear ran a real 1M context on my Mac Studio](https://omarshabab.com/kimi-linear-1m-context/)
+- [The two numbers that decide local LLMs: 100 tokens/sec and 1M context](https://omarshabab.com/local-llm-two-numbers/)
+- [Local LLM Benchmark: Gemma 4 vs Qwen 3.5](https://omarshabab.com/llm-benchmark/)
+- [Serving ML Models Serverlessly](https://www.youtube.com/watch?v=Fon3xvdAKe4) (AWS UG Malaysia)
 - [Practical Introduction to NLP](https://github.com/omar16100/Practical-Introduction-To-NLP)
-- [goingcloudnative.dev](https://goingcloudnative.dev) - Cloud computing educational content
 
 ## Connect
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ Currently at Singapore's largest grocery retailer, where I build LLM platforms, 
 
 ## Contributing Elsewhere
 
-Open source contributions to [psd-tools](https://github.com/psd-tools/psd-tools) (drop shadow and outer glow layer effect rendering), [App-Store-Connect-CLI](https://github.com/rorkai/App-Store-Connect-CLI) (submission validation, localization updates, price filtering), [whatsapp-mcp](https://github.com/lharries/whatsapp-mcp), [HistoryHound](https://github.com/pkmishra/HistoryHound), and [aws-samples](https://github.com/aws-samples).
+Merged: [App-Store-Connect-CLI](https://github.com/rorkai/App-Store-Connect-CLI) (submission validation, localization updates, price point filtering, stale review handling) and [aws-codecommit-devops-model](https://github.com/aws-samples/aws-codecommit-devops-model).
+
+Open: [psd-tools](https://github.com/psd-tools/psd-tools) (drop shadow and outer glow layer effect rendering), [whatsapp-mcp](https://github.com/lharries/whatsapp-mcp) (context-aware whatsmeow API), [HistoryHound](https://github.com/pkmishra/HistoryHound) (stdio transport, Chrome profile detection).
 
 ## Tech Stack
 


### PR DESCRIPTION
Refreshes the profile README, last updated 28 Jan 2026.

## What changed
- Projects grouped by domain (Systems & CLI, AI Tooling, ML & Experiments, Web) instead of a 3-row table
- Adds 10 repos shipped since January: surge, fanpro, speedlog, batteryconsole, logi_mx_auto_switch, reddit-mcp-server, skills, llm-benchmark, bengali-ocr-finetune, saas_template
- Removes dead `goingcloudnative.dev` link (no DNS A record), replaced with 4 live posts from omarshabab.com
- Tech stack corrected to what the repos actually contain. Dropped Go, TensorFlow, LangChain, Airflow, Terraform (no active repo uses them); added C, Metal, IOKit, MLX, GGUF, MCP, Cloudflare
- New section for external contributions, split into merged and open

## Verification
- All 30 URLs return 200 (atlassiancli.com checked via `--resolve`, local resolver is stale)
- Blog post pages confirmed by title, not just status code (the site returns 200 for unknown paths)
- Metrics date-stamped and traced: 28 stars (GitHub API), 7,217 release asset downloads (summed across all releases), 541 crates.io downloads (crate owner confirmed as omar16100)
- `parsnip` crates.io figure deliberately excluded: that crate belongs to a different author
- fanpro IOKit, bengali-ocr-finetune mlx_vlm, batteryconsole Rust all confirmed against repo contents
- No em dashes